### PR TITLE
Update mcp_server.py for mcp 2.0 compatibility

### DIFF
--- a/src/pyauthenticator/mcp_server.py
+++ b/src/pyauthenticator/mcp_server.py
@@ -8,7 +8,7 @@ import io
 from typing import Any, Dict, List, Optional
 
 import qrcode
-from mcp.server.fastmcp import FastMCP, Image
+from mcp.server.mcpserver import Image, MCPServer
 from PIL import Image as PilImage
 from pyzbar.pyzbar import decode
 
@@ -131,9 +131,9 @@ def get_qrcode(service: str) -> Any:
 
 def create_mcp_server() -> Any:
     """
-    Create the FastMCP server instance.
+    Create the MCPServer instance.
     """
-    mcp = FastMCP("pyauthenticator")
+    mcp = MCPServer("pyauthenticator")
     mcp.tool(
         name="get_code",
         description="Generate a two factor authentication code for a configured service.",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -92,7 +92,7 @@ class MCPServerTest(unittest.TestCase):
     def test_get_qrcode(self):
         qrcode_image = get_qrcode(service="test")
         image_content = qrcode_image.to_image_content()
-        self.assertEqual(image_content.mimeType, "image/png")
+        self.assertEqual(image_content.mime_type, "image/png")
         self.assertTrue(len(image_content.data) > 0)
 
     def test_unknown_service_errors_include_available_services(self):


### PR DESCRIPTION
## Summary
- mcp 2.0 removed `FastMCP` from `mcp.server.fastmcp` in favor of `MCPServer` in `mcp.server.mcpserver`; updated the import and instantiation in `mcp_server.py` accordingly.
- `ImageContent`'s Python attribute was renamed from `mimeType` to `mime_type` in mcp 2.0; updated the corresponding test assertion.

## Test plan
- [x] `python -m unittest tests.test_mcp_server -v` passes (9/9) against `mcp==2.0.0`
- [x] `pre-commit run --files src/pyauthenticator/mcp_server.py tests/test_mcp_server.py` passes (ruff lint + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)