### PR TITLE
Add standalone problem-oriented docs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,8 @@ pyauthenticator myservice
 OTP="$(pyauthenticator myservice)"
 ```
 
+See [Using TOTP codes in shell scripts and CLI workflows](https://github.com/jan-janssen/pyauthenticator/blob/main/docs/shell-automation.md) for more examples.
+
 ### Python applications
 
 ```python
@@ -348,9 +350,13 @@ from pyauthenticator import get_two_factor_code
 otp = get_two_factor_code("myservice")
 ```
 
+See [Generating TOTP codes from Python](https://github.com/jan-janssen/pyauthenticator/blob/main/docs/python-totp.md) for more examples.
+
 ### SSH and remote-system automation
 
 `pyauthenticator` can be combined with `SSH_ASKPASS` when an SSH login requires a password followed by a TOTP code.
+
+See [Automating SSH logins that require a password and a TOTP code](https://github.com/jan-janssen/pyauthenticator/blob/main/docs/ssh-askpass.md) for a complete, working example.
 
 `ssh` invokes the program configured as `SSH_ASKPASS` whenever it needs to request input, passing the prompt text as an argument. Setting `SSH_ASKPASS_REQUIRE=force` makes `ssh` use this program even when run from an interactive terminal.
 
@@ -395,6 +401,8 @@ The exact prompt text (`Your OTP:` in this example) depends on the SSH server an
 ### Agent and MCP workflows
 
 The optional MCP server exposes configured TOTP credentials to MCP-compatible applications while retaining the same local credential store used by the CLI and Python interfaces.
+
+See [Giving an MCP agent (e.g. Claude) access to TOTP codes](https://github.com/jan-janssen/pyauthenticator/blob/main/docs/mcp.md) for a complete setup and example.
 
 ## Support
 

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,6 +1,10 @@
 format: jb-book
 root: README.md
 chapters:
+- file: ssh-askpass.md
+- file: shell-automation.md
+- file: python-totp.md
+- file: mcp.md
 - file: technology.ipynb
 - file: implementation.ipynb
 - file: summary.md

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,90 @@
+# Giving an MCP agent (e.g. Claude) access to TOTP codes
+
+## Problem
+
+An AI agent connected through [MCP](https://modelcontextprotocol.io/) (for example Claude Desktop, or another MCP-compatible host) is asked to carry out a task that involves logging into a service protected by two-factor authentication — filling in a web form, calling an API, or completing an SSH session — and needs a valid TOTP code to do so, without a person relaying it manually.
+
+[`pyauthenticator`](https://github.com/jan-janssen/pyauthenticator) ships an MCP server that exposes the same local TOTP credential store used by its command-line and Python interfaces as a small set of MCP tools.
+
+## Installation
+
+```bash
+pip install "pyauthenticator[mcp]"
+```
+
+This installs the `pyauthenticator-mcp` executable, requires Python 3.10+.
+
+## Configuration
+
+Find the absolute path to the installed executable:
+
+```bash
+which pyauthenticator-mcp
+```
+
+Using an absolute path is recommended because desktop applications commonly start MCP servers without loading the environment configuration of an interactive shell.
+
+Add it to the host's MCP server configuration, for example:
+
+```json
+{
+  "mcpServers": {
+    "pyauthenticator": {
+      "command": "/absolute/path/to/pyauthenticator-mcp"
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Claude Desktop stores its MCP configuration in `claude_desktop_config.json`, accessible via **Settings → Developer → Edit Config**. Typical locations:
+
+* macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+* Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+* Linux: `~/.config/Claude/claude_desktop_config.json`
+
+Only add or modify the `mcpServers` entry needed for `pyauthenticator`; leave unrelated settings unchanged:
+
+```json
+{
+  "mcpServers": {
+    "pyauthenticator": {
+      "command": "/Users/<you>/mambaforge/bin/pyauthenticator-mcp"
+    }
+  },
+  "preferences": {
+    "...": "..."
+  }
+}
+```
+
+Restart Claude Desktop after editing the file.
+
+## Available tools
+
+| Tool | Arguments | Description |
+| --- | --- | --- |
+| `get_code` | `service: str` | Generate a two-factor authentication code for a configured service. |
+| `list_services` | – | List configured service names. |
+| `add_service` | `service: str`, `qrcode_path: Optional[str]`, `qrcode_base64: Optional[str]` | Add a service from a QR-code file or base64-encoded PNG. |
+| `remove_service` | `service: str` | Remove a configured service. |
+| `get_qrcode` | `service: str` | Return the QR code for a configured service as an MCP image. |
+
+`get_code`, `remove_service`, and `get_qrcode` report the currently configured services when the requested service does not exist, so an agent can recover from a typo by listing what's available.
+
+## Example interaction
+
+Once configured, an agent can be asked directly, e.g.:
+
+> "Log into the staging dashboard and check the last deploy status. The two-factor code is under the service name `staging`."
+
+The agent calls `list_services` to confirm `staging` exists (or `add_service` first, if a QR code needs to be imported), then `get_code("staging")` to retrieve the current code at the point it's needed in the login flow.
+
+## Shared configuration
+
+The MCP server reads and writes the same `~/.pyauthenticator` configuration file as the command-line and Python interfaces. A service added through the CLI (`pyauthenticator myservice --add ...`) is immediately visible to `list_services`, and vice versa — see [Using TOTP codes in shell scripts and CLI workflows](shell-automation.md) and [Generating TOTP codes from Python](python-totp.md).
+
+## Security considerations
+
+Exposing `get_code` to an agent gives that agent — and anything that can direct its actions — the ability to generate valid two-factor codes on demand. Only configure this for services and organizations where automated TOTP use is permitted, be deliberate about which services are imported into the shared configuration file, and treat `~/.pyauthenticator` like any other credential file. See the [security considerations in the README](https://github.com/jan-janssen/pyauthenticator#security-considerations) for more detail.

--- a/docs/python-totp.md
+++ b/docs/python-totp.md
@@ -1,0 +1,101 @@
+# Generating TOTP codes from Python
+
+## Problem
+
+A Python application, script, or test suite needs to authenticate against a service protected by time-based one-time passwords (TOTP), without a person available to read a code off an authenticator app and type it in — for example an integration test that logs into a real staging environment, or a browser-automation script (Selenium/Playwright) driving a login form that has a TOTP step.
+
+[`pyauthenticator`](https://github.com/jan-janssen/pyauthenticator) stores TOTP credentials locally (imported once from the same QR code used to set up an authenticator app) and exposes them through a small Python API, so a script can request the current code the same way it would read any other local configuration.
+
+## Prerequisites
+
+Install `pyauthenticator`:
+
+```bash
+pip install pyauthenticator
+```
+
+Import the account once, from the QR code shown when the service's two-factor authentication was configured:
+
+```bash
+pyauthenticator myservice --add ~/Desktop/myservice-qrcode.png
+```
+
+This can also be done from Python, see [Adding an account from Python](#adding-an-account-from-python) below.
+
+## Generating a code
+
+```python
+from pyauthenticator import get_two_factor_code
+
+code = get_two_factor_code("myservice")
+print(code)  # e.g. "087078"
+```
+
+`get_two_factor_code()` always returns the code valid for the current 30-second TOTP window, so call it immediately before using the result rather than caching it.
+
+## Example: logging into a web form with Playwright
+
+```python
+from playwright.sync_api import sync_playwright
+
+from pyauthenticator import get_two_factor_code
+
+with sync_playwright() as playwright:
+    browser = playwright.chromium.launch()
+    page = browser.new_page()
+    page.goto("https://example.com/login")
+
+    page.fill("#username", "me")
+    page.fill("#password", "...")
+    page.click("#submit")
+
+    # Generate the OTP right before it's needed, since it is only valid
+    # for a short, fixed window.
+    page.fill("#otp", get_two_factor_code("myservice"))
+    page.click("#verify")
+
+    browser.close()
+```
+
+## Example: an integration test fixture
+
+```python
+import pytest
+
+from pyauthenticator import get_two_factor_code
+
+from myapp.client import Client
+
+
+@pytest.fixture
+def authenticated_client():
+    client = Client(base_url="https://staging.example.com")
+    client.login(username="ci-bot", password="...", otp=get_two_factor_code("myservice"))
+    return client
+
+
+def test_something(authenticated_client):
+    assert authenticated_client.get("/me").status_code == 200
+```
+
+## Adding an account from Python
+
+Accounts can also be imported and managed without going through the command line:
+
+```python
+from pyauthenticator import add_two_factor_provider, list_two_factor_providers
+
+add_two_factor_provider("myservice", "/path/to/myservice-qrcode.png")
+print(list_two_factor_providers())  # ["myservice"]
+```
+
+All three interfaces — Python, the command line, and the [MCP server](mcp.md) — read and write the same local configuration file (`~/.pyauthenticator`), so an account added from one is immediately available from the others.
+
+## Related recipes
+
+* [Using TOTP codes in shell scripts and CLI workflows](shell-automation.md) — the same functionality from the command line instead of Python.
+* [Automating SSH logins that require a password and a TOTP code](ssh-askpass.md) — feeding a generated code to `ssh` via `SSH_ASKPASS`.
+
+## Security considerations
+
+`get_two_factor_code()` returns a valid, live authentication credential. Only automate TOTP entry when this is consistent with the target service's and organization's policies, and prefer a dedicated automation credential (API token, application password, service account) when the target system provides one. See the [security considerations in the README](https://github.com/jan-janssen/pyauthenticator#security-considerations) for more detail.

--- a/docs/shell-automation.md
+++ b/docs/shell-automation.md
@@ -1,0 +1,84 @@
+# Using TOTP codes in shell scripts and CLI workflows
+
+## Problem
+
+A shell script, cron job, or CI step needs to authenticate against a service that requires a time-based one-time password (TOTP), but there's no interactive user available to read a code off a phone and type it in.
+
+[`pyauthenticator`](https://github.com/jan-janssen/pyauthenticator) stores TOTP credentials locally (imported once from the same QR code used to set up an authenticator app) and prints the current code on demand, so it can be called from any shell script like any other CLI tool.
+
+## Prerequisites
+
+Install `pyauthenticator`:
+
+```bash
+pip install pyauthenticator
+```
+
+Import the account once, from the QR code shown when the service's two-factor authentication was configured:
+
+```bash
+pyauthenticator myservice --add ~/Desktop/myservice-qrcode.png
+```
+
+## Capturing a code in a variable
+
+```bash
+OTP="$(pyauthenticator myservice)"
+echo "Current code: $OTP"
+```
+
+## Example: passing a TOTP code to a CLI tool
+
+Many command-line tools accept a one-time password as an argument or header. For example, a REST API that requires a TOTP header on login:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+TOKEN=$(
+  curl -sf -X POST https://example.com/api/login \
+    -H "Content-Type: application/json" \
+    -H "X-OTP-Code: $(pyauthenticator myservice)" \
+    -d '{"username": "me"}' \
+  | jq -r '.token'
+)
+
+echo "Logged in, token: $TOKEN"
+```
+
+Because `pyauthenticator myservice` is only valid for the current 30-second TOTP window, generate it inline (as above) right before it's used, rather than reusing a value captured earlier in a long-running script.
+
+## Example: waiting out an expiring code
+
+If a script runs close to a 30-second window boundary, a code generated a moment too early can expire before it reaches the server. A simple retry loop makes this robust without needing to know the exact TOTP period:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+attempt_login() {
+    curl -sf -X POST https://example.com/api/login \
+        -H "X-OTP-Code: $(pyauthenticator myservice)" \
+        -d '{"username": "me"}'
+}
+
+for attempt in 1 2 3; do
+    if attempt_login; then
+        exit 0
+    fi
+    echo "Login attempt $attempt failed, retrying..." >&2
+    sleep 2
+done
+
+echo "Login failed after 3 attempts" >&2
+exit 1
+```
+
+## Related recipes
+
+* [Automating SSH logins that require a password and a TOTP code](ssh-askpass.md) — a more specific case where the OTP is one of two prompts `ssh` itself needs answered.
+* [Generating TOTP codes from Python](python-totp.md) — the same functionality from a Python script instead of the shell.
+
+## Security considerations
+
+Storing and using a TOTP secret from an automated script removes the "something you have, checked by a human" property that two-factor authentication is meant to provide. Only automate TOTP entry when this is consistent with the target service's and organization's policies, and prefer a dedicated automation credential (API token, application password, service account) when one is available. See the [security considerations in the README](https://github.com/jan-janssen/pyauthenticator#security-considerations) for more detail.

--- a/docs/ssh-askpass.md
+++ b/docs/ssh-askpass.md
@@ -1,0 +1,96 @@
+# Automating SSH logins that require a password and a TOTP code
+
+## Problem
+
+Some SSH servers are configured with two-factor authentication: after the password prompt, the server (typically via a PAM module) asks for a second, time-based one-time password (TOTP) — often shown as a prompt like `Your OTP:` or `Verification code:`. Tools that automate SSH sessions (batch jobs, `rsync` wrappers, CI runners, IDE remote hosts) normally only handle the password prompt, so a second interactive prompt breaks them.
+
+OpenSSH already has a mechanism for answering prompts non-interactively: `SSH_ASKPASS`. This page shows a complete, working setup that answers both prompts — the password from a local secret store and the OTP from [`pyauthenticator`](https://github.com/jan-janssen/pyauthenticator) — without any manual typing.
+
+## How `SSH_ASKPASS` works
+
+When `ssh` needs to ask the user something and cannot use the controlling terminal (or `SSH_ASKPASS_REQUIRE` forces it), it runs the program named by the `SSH_ASKPASS` environment variable and passes the prompt text as its first argument. Whatever that program prints to stdout is used as the answer.
+
+Two environment variables control this:
+
+* `SSH_ASKPASS` — path to an executable that receives the prompt as `$1` and prints the answer.
+* `SSH_ASKPASS_REQUIRE=force` — makes `ssh` use `SSH_ASKPASS` even when run from an interactive terminal (without this, `ssh` normally only uses it when there is no terminal available, e.g. when launched from a GUI).
+
+Because the helper program receives the *prompt text*, a single script can distinguish a password prompt from an OTP prompt and answer each differently.
+
+## Prerequisites
+
+1. Install `pyauthenticator`:
+
+   ```bash
+   pip install pyauthenticator
+   ```
+
+2. Import the TOTP secret once, from the QR code your SSH provider/computing centre gave you when enrolling your authenticator app:
+
+   ```bash
+   pyauthenticator myserver --add ~/Desktop/myserver-qrcode.png
+   ```
+
+   From then on, `pyauthenticator myserver` prints the current 6-digit code.
+
+## Complete example
+
+Create `~/.ssh/askpass-helper.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROMPT="${1:-}"
+
+case "$PROMPT" in
+    *"'s password:"*)
+        # Retrieve the password from a secure credential store, e.g. the
+        # macOS keychain:
+        #   security find-generic-password -s myserver -w
+        # or a password manager's CLI (1Password `op`, `pass`, etc.).
+        security find-generic-password -s myserver -w
+        ;;
+
+    *"Your OTP:"*|*"Verification code:"*)
+        # Generate the current TOTP code for the "myserver" account.
+        exec pyauthenticator myserver
+        ;;
+
+    *)
+        echo "Unexpected SSH prompt: $PROMPT" >&2
+        exit 1
+        ;;
+esac
+```
+
+Make it executable:
+
+```bash
+chmod +x ~/.ssh/askpass-helper.sh
+```
+
+Then export the two environment variables, for example in `~/.bashrc` or `~/.zshrc`:
+
+```bash
+export SSH_ASKPASS="$HOME/.ssh/askpass-helper.sh"
+export SSH_ASKPASS_REQUIRE=force
+```
+
+Open a new shell (or `source` the file) and connect as usual:
+
+```bash
+ssh myserver
+```
+
+`ssh` now calls `askpass-helper.sh` for the password prompt and again for the OTP prompt, and the connection completes without any manual input.
+
+## Adjusting the prompt text
+
+The `case` statement matches on the literal prompt text, which depends on the SSH server and PAM module configuration of the target system. `'s password:` is the standard OpenSSH password prompt (preceded by the username). `Your OTP:` and `Verification code:` are common phrasings for PAM-based TOTP modules (e.g. `pam_oath`, `google-authenticator`), but the exact wording varies by system. Run `ssh -v myserver` once to see the literal prompt text logged, and adjust the `case` patterns accordingly.
+
+## Security considerations
+
+This setup removes the human-in-the-loop step that two-factor authentication is designed to provide: the password and the TOTP secret both end up readable by an automated process on the same machine. Some organizations and computing centres explicitly prohibit this kind of automation.
+
+**Only set this up when it is consistent with the security policies of the systems and organizations you connect to.** Check with the relevant administrators or computing centre first, and prefer a dedicated automation credential (an SSH key, an API token, a service account) whenever the target system offers one — see [Generating TOTP codes from Python](python-totp.md) and the [security considerations in the README](https://github.com/jan-janssen/pyauthenticator#security-considerations) for more on when TOTP automation is and isn't appropriate.


### PR DESCRIPTION
## Summary
- Add four standalone pages under `docs/`, each answering one specific automation problem independently of the README:
  - `docs/ssh-askpass.md` — complete, working `SSH_ASKPASS` example for SSH logins that require a password + TOTP code (the narrow, underdocumented case this PR prioritizes)
  - `docs/shell-automation.md` — using TOTP codes in shell scripts / CLI workflows
  - `docs/python-totp.md` — generating TOTP codes from Python (incl. Playwright/pytest examples)
  - `docs/mcp.md` — giving an MCP agent (e.g. Claude Desktop) access to TOTP codes
- Register the new pages in `docs/_toc.yml` so they're built into the Jupyter Book / Read the Docs site
- Cross-link the pages from the README's existing "Use cases" section, and cross-link the new pages to each other

## Test plan
- [x] Reviewed each page renders as valid Markdown and code fences are correctly closed
- [x] Verified CLI/Python/MCP examples match current function signatures in `src/pyauthenticator/{_cmd,_user,api,mcp_server}.py`
- N/A (documentation-only change; no code paths affected)