### PR TITLE
Add TOTP algorithm deep-dive and security considerations to technology.ipynb

### DIFF
--- a/notebooks/technology.ipynb
+++ b/notebooks/technology.ipynb
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "id": "e70505b4-332a-4620-9d42-4d6d98a53fbf",
    "metadata": {
     "trusted": true
@@ -144,16 +144,41 @@
     {
      "data": {
       "text/plain": [
-       "'152185'"
+       "'426192'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "pyotp.TOTP(s=secret).now()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d32568af",
+   "source": "### Under the hood: implementing TOTP from RFC 6238\n\n`pyotp.TOTP(...).now()` hides five steps defined by [RFC 6238](https://datatracker.ietf.org/doc/html/rfc6238), which extends the counter-based [HOTP algorithm (RFC 4226)](https://datatracker.ietf.org/doc/html/rfc4226) by deriving the counter from time instead of an incrementing counter:\n\n1. **Shared secret** — the Base32 `secret` decoded above; known to both the authenticator app and the service, and never transmitted again after the initial qrcode scan.\n2. **Time counter** — the current Unix time is divided into fixed windows, 30 seconds by default: `T = floor((unix_time − T0) / X)`, with `T0 = 0` and step `X = 30`.\n3. **HMAC** — `T` is packed into an 8-byte big-endian integer and hashed together with the secret key using HMAC-SHA1 (SHA256/SHA512 are also valid, selected via the `otpauth://` URI's `algorithm` parameter), producing a 20-byte digest.\n4. **Dynamic truncation** — the low nibble of the digest's *last* byte is used as an offset; the 4 bytes starting at that offset are read as a big-endian integer with the top bit cleared.\n5. **Modulo** — that integer, taken modulo `10^digits` (6 by default) and left-padded with zeros, is the code shown on screen.\n\nThe cell below reimplements these five steps directly, without `pyotp`, and produces the same code as `pyotp.TOTP(...).now()` above (both are computed for the same 30-second window).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "e4574e0f",
+   "source": "import base64\nimport hashlib\nimport hmac\nimport struct\nimport time\n\n\ndef totp_from_scratch(secret_b32: str, digits: int = 6, step: int = 30, t0: int = 0) -> str:\n    padding = \"=\" * ((8 - len(secret_b32) % 8) % 8)\n    key = base64.b32decode(secret_b32.upper() + padding)\n    counter = int((time.time() - t0) // step)\n    counter_bytes = struct.pack(\">Q\", counter)\n\n    digest = hmac.new(key, counter_bytes, hashlib.sha1).digest()\n    offset = digest[-1] & 0x0F\n    truncated = struct.unpack(\">I\", digest[offset : offset + 4])[0] & 0x7FFFFFFF\n\n    return str(truncated % (10**digits)).zfill(digits)\n\n\ntotp_from_scratch(secret)",
+   "metadata": {},
+   "execution_count": 10,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'426192'"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
    ]
   },
   {
@@ -193,6 +218,12 @@
    "source": [
     "qrcode.make(result).save(\"test.png\", \"PNG\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22512ded",
+   "source": "## Security considerations\n\nThe properties that make TOTP convenient for automation are the same ones worth understanding when reasoning about its security.\n\n**What TOTP protects against well:**\n* **Short-lived codes** — each code is only valid for one time-step (30 seconds by default, plus the small drift tolerance below), so a code intercepted after it expires is worthless.\n* **No secret in transit** — after the initial qrcode scan, only the 6-digit code crosses the network; the shared secret itself never has to be sent again.\n* **Replay resistance** — a server that tracks the last accepted time-step rejects a previously-used code outright, even if it's still within its validity window.\n* **Offline generation** — codes are derived locally from the secret and the clock, with no SMS/email delivery step to intercept or redirect (unlike SMS-based two-factor authentication, which is also vulnerable to SIM swapping).\n\n**What TOTP does *not* protect against:**\n* **Real-time phishing (adversary-in-the-middle)** — a fake login page that immediately forwards a captured password *and* TOTP code to the real service can still authenticate as the victim, since the code stays valid for several seconds after it's generated. TOTP raises the bar over a password alone, but unlike [FIDO2/WebAuthn passkeys](https://webauthn.guide/), it does not stop this class of attack.\n* **Secret/seed compromise** — anyone who obtains the shared secret (from a compromised device, a leaked backup, or a stolen credential file) can generate valid codes indefinitely, without needing to intercept anything in real time.\n* **Malware on the trusted device** — if the device holding the secret is itself compromised, malware can read the secret or the generated codes directly.\n* **Clock drift** — the counter `T` from the previous section only matches between authenticator and server if their clocks roughly agree. Servers therefore accept a small window of adjacent time-steps (commonly ±1, i.e. ±30 seconds) to tolerate drift; a device whose clock has drifted further than that will generate codes the server rejects.\n\nBecause of the secret-compromise point above, using TOTP from an automated process — as `pyauthenticator` is designed to do — changes the traditional security model: the value of two-factor authentication comes from combining *something you know* (a password) with *something you have* (a device only the user controls), and once both live on the same automated machine, that separation is gone. See [pyauthenticator's security considerations](https://github.com/jan-janssen/pyauthenticator#security-considerations) for how to weigh that trade-off, and this [background article on TOTP](https://medium.com/@raditya.mit/totp-demystified-how-time-based-one-time-passwords-secure-your-logins-3798339ed29c) for further reading.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Add a "under the hood" subsection to `notebooks/technology.ipynb` that reimplements TOTP from RFC 6238 (HMAC, dynamic truncation, modulo) using only the standard library, and verifies it produces the same code as `pyotp.TOTP(...).now()`
- Add a "Security considerations" section covering what TOTP protects against well (short-lived codes, no secret in transit, replay resistance, offline generation) and what it does not (real-time/adversary-in-the-middle phishing, secret compromise, device malware, clock drift), and how automating TOTP entry (as `pyauthenticator` does) affects the traditional 2FA security model
- Informed by [this TOTP background article](https://medium.com/@raditya.mit/totp-demystified-how-time-based-one-time-passwords-secure-your-logins-3798339ed29c), cited as further reading in the notebook

## Test plan
- [x] Verified the from-scratch implementation matches `pyotp`'s output for the same secret/time window (both cells' baked-in outputs, `426192`, were captured from the same run)
- [x] Validated the notebook is well-formed JSON (`json.load` succeeds, 22 cells)
- N/A (documentation-only change; no code paths affected)