### PR TITLE
Fix dead Documentation URL in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/jan-janssen/pyauthenticator"
-Documentation = "https://github.com/jan-janssen/pyauthenticator/blob/master/README.md"
+Documentation = "https://pyauthenticator.readthedocs.io"
 Source = "https://github.com/jan-janssen/pyauthenticator"
 Tracker = "https://github.com/jan-janssen/pyauthenticator/issues"
 


### PR DESCRIPTION
## Summary
- `project.urls.Documentation` pointed at `github.com/jan-janssen/pyauthenticator/blob/master/README.md` — the `master` branch doesn't exist (default branch is `main`), so this link 404s from the PyPI project page today
- Point it at `https://pyauthenticator.readthedocs.io` instead, which is also a much richer landing page than a raw README render

## Test plan
- N/A (metadata-only change; takes effect on the next release)